### PR TITLE
Add Travis Continuous Integration to the repo with Platform IO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   fast_finish: true
   include:
     - env: BOARD=uno PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=megaatmega2560 PLATFORMIO_CI_SRC=examples/Simple_Test
     - env: BOARD=diecimilaatmega328 PLATFORMIO_CI_SRC=examples/Simple_Test
     - env: BOARD=leonardo PLATFORMIO_CI_SRC=examples/Simple_Test
     - env: BOARD=nanoatmega328 PLATFORMIO_CI_SRC=examples/Simple_Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+python:
+  - "2.7"
+
+# Short duration job, use the container/without sudo image as it boots faster
+sudo: false
+# Use the latest Travis images since they are more up to date than the stable release.
+group: edge
+
+cache:
+  directories:
+    - "~/.platformio"
+
+matrix:
+  fast_finish: true
+  include:
+    - env: BOARD=uno PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=diecimilaatmega328 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=leonardo PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=nanoatmega328 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=pro16MHzatmega328 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensy20 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensy20pp PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensylc PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensy30 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensy31 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensy35 PLATFORMIO_CI_SRC=examples/Simple_Test
+    - env: BOARD=teensy36 PLATFORMIO_CI_SRC=examples/Simple_Test
+
+install:
+  - pip install -U platformio
+
+script:
+  - platformio ci --lib="." --board=$BOARD

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
   - pip install -U platformio
 
 script:
-  - platformio ci --lib="." --board=$BOARD
+  - platformio ci --lib="src" --board=$BOARD


### PR DESCRIPTION
To catch careless typos etc.

@DaAwesomeP you'll need to enable Travis on the repo ( https://travis-ci.org/DaAwesomeP/dmxusb ), and I'd then suggest you protect the branch in GitHub so you can only merge if Travis passes.

Currently this is just testing against a range of Arduino and Teensy boards, we could test against a lot more flavours if it's worth it, or some additional specific ones:
http://platformio.org/boards

There are also some warnings, which should probably be fixed:
https://travis-ci.org/peternewman/dmxusb/jobs/306081175#L578

These could also be caught automatically with -werror, which might make sense

We could also enable a C++ linter if you have a preferred one?