### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,5 +8,6 @@ category=Communication
 url=https://github.com/DaAwesomeP/dmxusb
 architectures=*
 includes=DMXUSB.h
+depends=elapsedMillis
 license=Apache-2.0
 bugs=https://github.com/DaAwesomeP/dmxusb/issues


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format